### PR TITLE
config: move all logs inside one dir

### DIFF
--- a/nethserver-flashstart-hybrid.spec
+++ b/nethserver-flashstart-hybrid.spec
@@ -53,6 +53,7 @@ cp -a api/* %{buildroot}/usr/libexec/nethserver/api/%{name}/
 chmod +x %{buildroot}/usr/libexec/nethserver/api/%{name}/*
 
 mkdir -p %{buildroot}/var/log/flashstart-hybrid-proc/
+mkdir -p %{buildroot}/var/log/flashstart-hybrid/
 
 %{genfilelist} %{buildroot} > %{name}-%{version}-filelist
 
@@ -61,6 +62,7 @@ mkdir -p %{buildroot}/var/log/flashstart-hybrid-proc/
 %dir %{_nseventsdir}/%{name}-update
 %dir %{_nsdbconfdir}/flashstart
 %dir /var/log/flashstart-hybrid-proc
+%dir /var/log/flashstart-hybrid
 %config(noreplace) /etc/flashstart-hybrid/*
 %doc COPYING
 

--- a/root/etc/e-smith/templates/dnsmasq-instance/99Log
+++ b/root/etc/e-smith/templates/dnsmasq-instance/99Log
@@ -2,6 +2,6 @@
 # 99Log
 #
 
-log-facility=/var/log/dnsmasq.log
+log-facility=/var/log/flashstart-hybrid/dnsmasq.log
 log-queries
 

--- a/root/etc/logrotate.d/flashstart-hybrid
+++ b/root/etc/logrotate.d/flashstart-hybrid
@@ -1,5 +1,5 @@
-/var/log/flashstart-hybrid.log {
+/var/log/flashstart-hybrid/*.log {
     copytruncate
-    compress
     missingok
+    notifempty
 }

--- a/root/usr/libexec/flashstart-hybrid/bootstrap.var
+++ b/root/usr/libexec/flashstart-hybrid/bootstrap.var
@@ -10,7 +10,7 @@ PATH_LIB=$__DIR__/lib
 PATH_SRC=$__DIR__/src
 PATH_TEMPLATE=$__DIR__/template
 
-PATH_LOG=/var/log/
+PATH_LOG=/var/log/flashstart-hybrid/
 NAME_FILE_LOG=flashstart-hybrid.log
 
 #-------------------------------------------------------------
@@ -80,7 +80,7 @@ UPDATE_DIR_NAME=update
 #-------------------------------------------------------------
 # DNS SERVICE VAR
 #-------------------------------------------------------------
-DNSSRV_LOG_DIR=/var/log/
+DNSSRV_LOG_DIR=/var/log/flashstart-hybrid/
 NAME_DNSSRV_LOG_FILE=dnsmasq.log
 DNSSRV_LOG_FILE=$DNSSRV_LOG_DIR/$NAME_DNSSRV_LOG_FILE
 


### PR DESCRIPTION
Logs are now saved under /var/log/flashstart-hybrid directory to ease the management and rotation.

Do not force compression on logrotate, but comply with system-wide configuration.