### PR TITLE
Optimization of flashstart-hybrid service startup and actions

### DIFF
--- a/root/etc/e-smith/events/actions/flashstarthybrid-init
+++ b/root/etc/e-smith/events/actions/flashstarthybrid-init
@@ -36,9 +36,7 @@ done
 
 # proceed only if enabled
 if [ "$FS_STATUS" == "1" ]; then 
-	# download new dns configuration
-	$SCRIPT_FS new_dns
-
+	
 	# get rule list from perl module
 	for line in $($PERL -e 'use FlashStartHybrid::IpsetDNS; my @l = FlashStartHybrid::IpsetDNS->return_row(); foreach my $e (@l) { print "$e->{profile};$e->{loID};$e->{loIP}\n"; }') ; do 
 		
@@ -61,8 +59,6 @@ if [ "$FS_STATUS" == "1" ]; then
 		systemctl enable --now dnsmasq@$i
 	done
 	
-	# call jobs
-	$SCRIPT_FS init_jobs 1
 else 
 	# Log
 	fn_log "$LOG_PROC" "$LOG_LABEL_INFO FlashStart disabled - does not proceed"

--- a/root/usr/libexec/flashstart-hybrid/fsdaemon
+++ b/root/usr/libexec/flashstart-hybrid/fsdaemon
@@ -12,6 +12,13 @@ if [ ! -d "$PROCEDURE_LOG_DIR" ]; then
 	mkdir $PROCEDURE_LOG_DIR
 fi
 
+# test connection
+TEST_CONNECTION=$(fn_wait_connection)
+if [ "$TEST_CONNECTION" == "0" ]; then
+  # log error
+  fn_log "SERVICE $SERVICE_FS" "CONNECTION ERROR"
+fi
+
 # check ipset 
 CHECK_IPSET=$($IPSET -L | grep "PROFILE-" | wc -l)
 if [ "$CHECK_IPSET" == "0" ]; then 

--- a/root/usr/libexec/flashstart-hybrid/fsdaemon
+++ b/root/usr/libexec/flashstart-hybrid/fsdaemon
@@ -15,13 +15,18 @@ fi
 # check ipset 
 CHECK_IPSET=$($IPSET -L | grep "PROFILE-" | wc -l)
 if [ "$CHECK_IPSET" == "0" ]; then 
-	# call init 
+	# download new dns configuration
+	if [ "$AUTH_EMAIL" != "" ]; then 
+		$SCRIPT_FS new_dns
+	fi
+	
+	# call init event
 	$SIGNAL_EVENT nethserver-flashstart-hybrid-save
-	
-elif [ "$AUTH_EMAIL" != "" ]; then 
-	# call init jobs only with file reset
+fi
+
+# call init jobs
+if [ "$AUTH_EMAIL" != "" ]; then
 	$SCRIPT_FS init_jobs 1
-	
 fi
 
 # send version to FlashStart

--- a/root/usr/libexec/flashstart-hybrid/lib/service.fn
+++ b/root/usr/libexec/flashstart-hybrid/lib/service.fn
@@ -174,7 +174,7 @@ fn_return_flashstart_status() {
 }
 
 fn_wait_connection() {
-	local MAX_LOOP=5
+	local MAX_LOOP=10
 
 	local COUNTER=0
 	local RESULT=0

--- a/root/usr/libexec/flashstart-hybrid/lib/service.fn
+++ b/root/usr/libexec/flashstart-hybrid/lib/service.fn
@@ -173,6 +173,24 @@ fn_return_flashstart_status() {
 	fi
 }
 
+fn_wait_connection() {
+	local MAX_LOOP=5
+
+	local COUNTER=0
+	local RESULT=0
+		
+	while [[ $COUNTER -lt $MAX_LOOP ]]; do	
+		TEST_API=$(fn_api_test)
+		if [ "$TEST_API" == "1" ]; then
+			RESULT=1
+			break	
+		fi
+		COUNTER=$((COUNTER+1))
+	done
+
+	echo $RESULT	
+}
+
 # API
 #-------------------------
 function fn_call_api() {
@@ -409,6 +427,21 @@ fn_api_prepare_file_data_object() {
 		sed  -i '1i {' $PREPARE_FILE
 		echo "}" >> $PREPARE_FILE
 	fi
+}
+
+fn_api_test() {
+	# set protocol
+	API_PROTOCOL="http://"
+	if [ "$API_HTTPS" = "1" ]; then
+		API_PROTOCOL="https://"
+	fi 
+	# set url 
+	API_URL=$API_PROTOCOL$API_BASEURL
+
+	# check api
+	local TEST=$(curl -s --head  --request GET "$API_URL" -k --connect-timeout $API_CURL_TIMEOUT | grep "200 OK" | wc -l)
+
+	echo "$TEST"
 }
 
 # SOFTWARE

--- a/root/usr/libexec/flashstart-hybrid/src/configure_catch_all
+++ b/root/usr/libexec/flashstart-hybrid/src/configure_catch_all
@@ -11,7 +11,7 @@ if [ "$INIT_SRC_INCLUDE" != "1" ]; then echo "call %SCRIPT_DIR%/%SCRIPT_FS% conf
 fn_log "$CALL_PROC" "$LOG_LABEL_INFO write file"
 
 # call new_dns on write only mode
-CHECK_RELOAD=$($SCRIPT_FS new_dns write_only)
+CHECK_RELOAD=$($SCRIPT_FS new_dns)
 
 if [ "$CHECK_RELOAD" = "1" ]; then
 	# log

--- a/root/usr/libexec/flashstart-hybrid/src/configure_catch_all
+++ b/root/usr/libexec/flashstart-hybrid/src/configure_catch_all
@@ -19,6 +19,9 @@ if [ "$CHECK_RELOAD" = "1" ]; then
 
 	# call reload firewall rule
 	$SIGNAL_EVENT nethserver-flashstart-hybrid-save
+	
+	# call init jobs
+	$SCRIPT_FS init_jobs 1
 fi
 
 


### PR DESCRIPTION
The update introduced the following changes:
- Removed procedures that require connection from `flashstarthybrid-init` event 
- Added  procedures that connect to APIs in `fsdaemon` script and `configure_catch_all` procedure
- Added test connection at startup