### PR TITLE
creatlinks: remove missing action in zone update

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -95,7 +95,6 @@ $event = 'flashstarthybrid-zone-update';
 
 event_actions($event, qw(
       flashstarthybrid-restart-dnsmasq 30
-      flashstarthybrid-expand-dnsmasq 40
 ));
 
 #


### PR DESCRIPTION
Removed `flashstarthybrid-expand-dnsmasq` action in `flashstarthybrid-zone-update` event  because it is unnecessary, the templates are expanded before service starts