### PR TITLE
Fix startup and service configuration 

### DIFF
--- a/root/etc/e-smith/events/actions/flashstarthybrid-init
+++ b/root/etc/e-smith/events/actions/flashstarthybrid-init
@@ -53,11 +53,14 @@ if [ "$FS_STATUS" == "1" ]; then
 		
 	done
 
-	systemctl enable --now flashstart-hybrid
+	systemctl enable flashstart-hybrid
 	for i in {0..4}
 	do
 		systemctl enable --now dnsmasq@$i
 	done
+	
+	# restart the service to initialize the ipset 
+	systemctl restart flashstart-hybrid
 	
 else 
 	# Log

--- a/root/usr/libexec/flashstart-hybrid/confs/queue_timing.conf
+++ b/root/usr/libexec/flashstart-hybrid/confs/queue_timing.conf
@@ -3,15 +3,10 @@
 #-------------------------------
 
 # set default queue time (multiple 10 second)
-DEFAULT_QTIME_REBRANDING=3600			# every 1 hour
 DEFAULT_QTIME_JOB=30					# every 30 sec
 DEFAULT_QTIME_SESS_CLEAR=3600			# every 1 hour
-DEFAULT_QTIME_SESS_CLEAR_TIMEOUT=300	# every 5 min
 DEFAULT_QTIME_SENDSTATS=300				# every 5 min
 DEFAULT_QTIME_SYSUPDATE=14400			# every 4 hours
-DEFAULT_QTIME_ADMINEXECUTE=20			# every 20 sec
-DEFAULT_QTIME_SYNCUSERGROUPS=3600		# every 1 hour
-DEFAULT_QTIME_LICENSEUPDATE=86400		# every 1 day
 
 
 # Add new timing with label DEFAULT_QTIME_ + CODE 

--- a/root/usr/libexec/flashstart-hybrid/confs/service.conf
+++ b/root/usr/libexec/flashstart-hybrid/confs/service.conf
@@ -25,7 +25,7 @@ API_HTTPS=1
 API_BASEURL=api.flashstart.com
 API_VERSION=1.0.0
 
-API_CURL_TIMEOUT=30 # seconds
+API_CURL_TIMEOUT=60 # seconds
 
 # set content type
 API_REQUEST_CONTENT_TYPE=application/json


### PR DESCRIPTION
The update introduced the following changes:

- Restart the service after configuration in flashstarthybrid-init action
- Removed unused timing parameters in the queue configuration file
- Increased curl timeout 