### PR TITLE
Add traffic redirect also for tcp protocol

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/89flashstart
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/89flashstart
@@ -56,12 +56,14 @@
                     # set rule for this setname
                     $OUT .= "?COMMENT FlashStart Rules on $elem->{profile} for port 53 \n";
                     $OUT .= "REDIRECT\t$zone:+$elem->{profile}$bypass_src_str\t$elem->{service_port}\tudp\t$dnsMasqPort\n";
+                    $OUT .= "REDIRECT\t$zone:+$elem->{profile}$bypass_src_str\t$elem->{service_port}\ttcp\t$dnsMasqPort\n";
                     $OUT .= "?COMMENT\n";
                 }
             }
             # For all [ catch-all profile ]
             $OUT .= "?COMMENT FlashStart Rules [catch-all] for port 53\n";
             $OUT .= "REDIRECT\t$zone$bypass_src_str_all\t$catch_all_port\tudp\t$dnsMasqPort\n";
+            $OUT .= "REDIRECT\t$zone$bypass_src_str_all\t$catch_all_port\ttcp\t$dnsMasqPort\n";
             $OUT .= "?COMMENT\n";
         }
     }


### PR DESCRIPTION
The current implementation redirects only requests on UDP port 53. However, some clients may use TCP port 53 to bypass the FlashStart filter.
To prevent these bypasses, I added a redirect for the TCP protocol as well.
This behavior aligns with the standard FlashStart integration (supported only in the PRO version) on NethServer.